### PR TITLE
Fix safari export

### DIFF
--- a/src/services/drawings/actions/exportBoard.js
+++ b/src/services/drawings/actions/exportBoard.js
@@ -15,7 +15,7 @@ import {
 export default function exportBoard() {
   Log.info('Service : Drawings : exportBoard');
 
-  return timeoutPromise((res) => {
+  return timeoutPromise((res, rej) => {
     const svgString = this.projects.drawings.exportSVG({
       asString : true,
       bounds   : 'content',
@@ -28,6 +28,11 @@ export default function exportBoard() {
 
     const image = new Image();
     image.src = url;
+
+    image.onerror = (err) => {
+      URL.revokeObjectURL(url);
+      rej(err)
+    }
 
     image.onload = () => {
       const canvas = document.createElement('canvas');

--- a/src/services/drawings/actions/exportBoard.js
+++ b/src/services/drawings/actions/exportBoard.js
@@ -23,7 +23,7 @@ export default function exportBoard() {
 
     const url = URL.createObjectURL(new Blob(
       [svgString],
-      { type : 'image/svg+xml;charset=utf-8' },
+      { type : 'image/svg+xml' },
     ));
 
     const image = new Image();


### PR DESCRIPTION
fixes #3: Due to error on image, safari export fails ungracefully leading to timeout.

